### PR TITLE
Fix `test_snap_nodes`

### DIFF
--- a/src/snkit/network.py
+++ b/src/snkit/network.py
@@ -264,12 +264,15 @@ def snap_nodes(network, threshold=None):
 
     geom_col = geometry_column_name(network.nodes)
     snapped_geoms = network.nodes[geom_col].apply(snap_node)
-    nodes = pandas.concat(
-        [
-            network.nodes.drop(geom_col, axis=1),
-            GeoDataFrame(snapped_geoms, columns=[geom_col]),
-        ],
-        axis=1,
+    nodes = GeoDataFrame(
+        pandas.concat(
+            [
+                network.nodes.drop(geom_col, axis=1),
+                GeoDataFrame(snapped_geoms, columns=[geom_col]),
+            ],
+            axis=1,
+        ),
+        crs=network.nodes.crs
     )
 
     return Network(nodes=nodes, edges=network.edges)


### PR DESCRIPTION
`test_snap_nodes` was failing here:
```
    snapped = snkit.network.snap_nodes(misaligned)
    assert_frame_equal(snapped.nodes, connected.nodes)
```
... as snapped.nodes and connected.nodes were not the same dtype (former DataFrame, latter GeoDataFrame). `snap_nodes` now changed to return nodes as `GeoDataFrame`.

Could alternatively compare the data in the test dataframes and not their types, I don't mind.