### PR TITLE
fix indexing error in drop_duplicate_geometries

### DIFF
--- a/src/snkit/network.py
+++ b/src/snkit/network.py
@@ -484,11 +484,13 @@ def node_connectivity_degree(node, network):
 
 def drop_duplicate_geometries(gdf, keep="first"):
     """Drop duplicate geometries from a dataframe"""
+
     # convert to wkb so drop_duplicates will work
     # discussed in https://github.com/geopandas/geopandas/issues/521
-    mask = gdf.geometry.apply(lambda geom: geom.wkb)
-    # use dropped duplicates index to drop from actual dataframe
-    return gdf.iloc[mask.drop_duplicates(keep=keep).index]
+    mask = gdf.geometry.apply(lambda geom: geom.wkb).drop_duplicates(keep=keep).index
+
+    # use mask to drop from actual dataframe
+    return gdf.loc[mask]
 
 
 def nearest_point_on_edges(point, edges):


### PR DESCRIPTION
When running `snkit.network.drop_duplicate_geometries` on a `GeoDataFrame` with indicies other than standard `{0, 1, 2, n-1, n}`, pandas would raise an out-of-bounds indexing error. Change: fix our indexing and add a test.