### PR TITLE
Accelerate labelling of network components

### DIFF
--- a/src/snkit/network.py
+++ b/src/snkit/network.py
@@ -827,23 +827,25 @@ def get_connected_components(network):
         return sorted(nx.connected_components(G), key=len, reverse=True)
 
 
-def add_component_ids(network, id_col="component_id"):
-    """Add column of component IDs to network data"""
-    # get connected components
-    connected_parts = get_connected_components(network)
-    # add unique id to each graph
-    network.edges[id_col] = 0  # init id_col
-    network.nodes[id_col] = 0  # init id_col
+def add_component_ids(network: Network, id_col: str = "component_id") -> Network:
+    """Add column of connected component IDs to network edges and nodes"""
+
+    # get connected components in descending size order
+    connected_parts: list[set] = get_connected_components(network)
+
+    # init id_col
+    network.edges[id_col] = 0
+    network.nodes[id_col] = 0
+
+    # add unique id for each graph component
     for count, part in enumerate(connected_parts):
+
         # edges
-        network.edges.loc[
-            (network.edges.from_id.isin(list(part)))
-            | (network.edges.to_id.isin(list(part))),
-            id_col,
-        ] = (
-            count + 1
-        )
+        edge_mask = network.edges.from_id.isin(part).values
+        network.edges.loc[edge_mask, id_col] = count + 1
+
         # nodes
-        network.nodes.loc[(network.nodes.id.isin(list(part))), id_col] = count + 1
-    # return
+        node_mask = network.nodes.id.isin(part).values
+        network.nodes.loc[node_mask, id_col] = count + 1
+
     return network

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -428,6 +428,31 @@ def bridged():
     return snkit.Network(edges=edges, nodes=nodes)
 
 
+@fixture
+def two_components(gap):
+    """Two network components
+    b
+    |
+    |   c--d--e
+    |
+    a
+    """
+    a = Point((0, 0))
+    b = Point((0, 2))
+    c = Point((1, 1))
+    d = Point((2, 1))
+    e = Point((3, 1))
+    nodes = GeoDataFrame([a, b, c, d, e], columns=["geometry"])
+    ab = LineString([a, b])
+    cd = LineString([c, d])
+    de = LineString([d, e])
+    edges = GeoDataFrame([ab, cd, de], columns=["geometry"])
+    network = snkit.Network(edges=edges, nodes=nodes)
+    network = snkit.network.add_ids(network)
+    network = snkit.network.add_topology(network)
+    return network
+
+
 def test_init():
     """Should create an empty network"""
     net = snkit.Network()
@@ -748,3 +773,8 @@ def test_to_networkx(connected):
     G_true.add_edge("n0", "n1", weight=2)
 
     assert graphs_equal(G, G_true)
+
+
+def test_add_component_ids(two_components):
+    labelled = snkit.network.add_component_ids(two_components)
+    assert all(labelled.edges.component_id == pd.Series([2, 1, 1]))


### PR DESCRIPTION
- Added a test for snkit.network.add_component_ids
- Tweaked `add_component_ids` for speed, now at something like 2/3rds the old runtime (or 1/2 with integer IDs).