### PR TITLE
configurable parallelism

### DIFF
--- a/src/snkit/network.py
+++ b/src/snkit/network.py
@@ -2,6 +2,7 @@
 """
 import logging
 import os
+from typing import Optional
 import warnings
 
 import geopandas
@@ -326,7 +327,7 @@ def _split_edges_at_nodes(
     return split_edges
 
 
-def split_edges_at_nodes(network: Network, tolerance: float = 1e-9, chunk_size: int | None = None):
+def split_edges_at_nodes(network: Network, tolerance: float = 1e-9, chunk_size: Optional[int] = None):
     """
     Split network edges where they intersect node geometries.
 

--- a/src/snkit/network.py
+++ b/src/snkit/network.py
@@ -29,9 +29,6 @@ from shapely.ops import split, linemerge, unary_union
 
 from collections import Counter
 
-# configure logging with a timestamp and process id prefix
-logging.basicConfig(format="%(asctime)s %(process)s %(message)s", level=logging.INFO)
-
 # optional progress bars
 if "SNKIT_PROGRESS" in os.environ and os.environ["SNKIT_PROGRESS"] in ("1", "TRUE"):
     try:


### PR DESCRIPTION
Configure parallelisation in `split_edges_at_nodes` via SNKIT_PROCESSES environment variable.