### PR TITLE
Fix nx NameError caused by type annotation

### DIFF
--- a/src/snkit/network.py
+++ b/src/snkit/network.py
@@ -1,5 +1,7 @@
 """Network representation and utilities
 """
+from __future__ import annotations
+
 from functools import partial
 import logging
 import multiprocessing


### PR DESCRIPTION
Add `from __future__ import annotations` - causes annotation to be evaluated when needed

With a fresh environment and default dependencies only:

```sh
$ micromamba env create -n snkit python=3.13
$ micromamba activate snkit
$ pip install -e .                                                                                                                                                                    $ python                                                                                                                                                                              Python 3.13.14 | packaged by conda-forge | (main, Jun 12 2026, 09:50:25) [GCC 14.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import networkx
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    import networkx
ModuleNotFoundError: No module named 'networkx'
>>> import snkit
```